### PR TITLE
Corrected --e to -e

### DIFF
--- a/contributing/development/configuring_an_ide/rider.rst
+++ b/contributing/development/configuring_an_ide/rider.rst
@@ -51,7 +51,7 @@ if you want to debug the editor, you need to configure the debugger first.
 
 ::
 
-  --e --path <path to the Godot project>
+  -e --path <path to the Godot project>
 
 This will tell the executable to debug the specified project without using the project manager.
 Use the root path to the project folder, not ``project.godot`` file path.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
